### PR TITLE
Fix 'key not found: com.twitter.querulous.query.QueryClass'

### DIFF
--- a/config/development.scala
+++ b/config/development.scala
@@ -35,6 +35,13 @@ class ProductionQueryEvaluator extends QueryEvaluator {
     poolSize = 10
     queueSize = 10000
   }
+  
+  query.timeouts = Map(
+    QueryClass.Select -> QueryTimeout(1.second),
+    QueryClass.Execute -> QueryTimeout(1.second),
+    QueryClass.SelectCopy -> QueryTimeout(15.seconds),
+    QueryClass.SelectModify -> QueryTimeout(3.seconds)
+  )
 }
 
 class ProductionNameServerReplica(host: String) extends Mysql {
@@ -53,13 +60,6 @@ class ProductionNameServerReplica(host: String) extends Mysql {
     database.timeout.foreach { t =>
       t.open = 1.second
     }
-
-    query.timeouts = Map(
-      QueryClass.Select -> QueryTimeout(1.second),
-      QueryClass.Execute -> QueryTimeout(1.second),
-      QueryClass.SelectCopy -> QueryTimeout(15.seconds),
-      QueryClass.SelectModify -> QueryTimeout(3.seconds)
-    )
   }
 }
 


### PR DESCRIPTION
Unless I'm missing something, this should be the easy development fix for:

```
key not found: com.twitter.querulous.query.QueryClass
```

reported in https://github.com/twitter/flockdb/issues/43

The SelectModify QuerelousQueryClass isn't available in the ProductionQueryEvaluator used by 'atomically' in SqlShard.scala using the default development.scala configuration.
## I'd love to contribute some more but need to know if I'm on the right track :-).

Moved query.timeouts from the ProductionNameServerReplica's ProductionQueryEvaluator to the actual ProductionQueryEvaluator declaration.
