### PR TITLE
fix: invalid LogConfigString in config/production.scala

### DIFF
--- a/config/production.scala
+++ b/config/production.scala
@@ -124,38 +124,36 @@ new FlockDB {
   }
 
   logging = new LogConfigString("""
-log {
-  filename = "/var/log/flock/production.log"
+filename = "/var/log/flock/production.log"
+level = "info"
+roll = "hourly"
+throttle_period_msec = 60000
+throttle_rate = 10
+truncate_stack_traces = 100
+
+w3c {
+  node = "w3c"
+  use_parents = false
+  filename = "/var/log/flock/w3c.log"
   level = "info"
   roll = "hourly"
-  throttle_period_msec = 60000
-  throttle_rate = 10
-  truncate_stack_traces = 100
+}
 
-  w3c {
-    node = "w3c"
-    use_parents = false
-    filename = "/var/log/flock/w3c.log"
-    level = "info"
-    roll = "hourly"
-  }
+stats {
+  node = "stats"
+  use_parents = false
+  level = "info"
+  scribe_category = "flock-stats"
+  scribe_server = "localhost"
+  scribe_max_packet_size = 100
+}
 
-  stats {
-    node = "stats"
-    use_parents = false
-    level = "info"
-    scribe_category = "flock-stats"
-    scribe_server = "localhost"
-    scribe_max_packet_size = 100
-  }
-
-  bad_jobs {
-    node = "bad_jobs"
-    use_parents = false
-    filename = "/var/log/flock/bad_jobs.log"
-    level = "info"
-    roll = "never"
-  }
+bad_jobs {
+  node = "bad_jobs"
+  use_parents = false
+  filename = "/var/log/flock/bad_jobs.log"
+  level = "info"
+  roll = "never"
 }
   """)
 }

--- a/src/test/scala/com/twitter/flockdb/ConfigValidationSpec.scala
+++ b/src/test/scala/com/twitter/flockdb/ConfigValidationSpec.scala
@@ -10,15 +10,18 @@ object ConfigValidationSpec extends Specification {
   "Configuration Validation" should {
     "production.scala" >> {
       val config = Eval[flockdb.config.FlockDB](new File("config/production.scala"))
+      config.logging()
       config mustNot beNull
     }
     "development.scala" >> {
       val config = Eval[flockdb.config.FlockDB](new File("config/development.scala"))
+      config.logging()
       config mustNot beNull
     }
 
     "test.scala" >> {
       val config = Eval[flockdb.config.FlockDB](new File("config/test.scala"))
+      config.logging()
       config mustNot beNull
     }
   }


### PR DESCRIPTION
"java -jar flockdb-xxx.jar config/production.scala" doesn't work. Because LogConfigString in production.scala is a invalid format.

ConfigValidationSpec tests loading log configuration, but doesn't validate it.
I guess the validating needs to call config.logging() that parses log configuration.
