### PR TITLE
allow normal edges to have their position changed;\nthis requires Multi o

### DIFF
--- a/src/main/scala/com/twitter/flockdb/EdgesService.scala
+++ b/src/main/scala/com/twitter/flockdb/EdgesService.scala
@@ -34,11 +34,12 @@ class EdgesService(val nameServer: NameServer[shards.Shard],
                    val schedule: PrioritizingJobScheduler,
                    future: Future,
                    intersectionQueryConfig: config.IntersectionQuery,
-                   aggregateJobsPageSize: Int) {
+                   aggregateJobsPageSize: Int,
+                   uuidGenerator: UuidGenerator) {
 
   private val log = Logger.get(getClass.getName)
   private val selectCompiler = new SelectCompiler(forwardingManager, intersectionQueryConfig)
-  private var executeCompiler = new ExecuteCompiler(schedule, forwardingManager, aggregateJobsPageSize)
+  private var executeCompiler = new ExecuteCompiler(schedule, forwardingManager, aggregateJobsPageSize, uuidGenerator)
 
   def shutdown() {
     schedule.shutdown()

--- a/src/main/scala/com/twitter/flockdb/Metadata.scala
+++ b/src/main/scala/com/twitter/flockdb/Metadata.scala
@@ -47,7 +47,7 @@ case class Metadata(sourceId: Long, state: State, count: Int, updatedAtSeconds: 
 
   def max(other: Metadata) = if (this > other) this else other
 
-  def schedule(tableId: Int, forwardingManager: ForwardingManager, scheduler: PrioritizingJobScheduler, priority: Int) = {
+  def schedule(tableId: Int, forwardingManager: ForwardingManager, scheduler: PrioritizingJobScheduler, priority: Int, uuidGenerator: UuidGenerator) = {
     val job = state match {
       case State.Normal => Unarchive
       case State.Removed => RemoveAll
@@ -55,7 +55,8 @@ case class Metadata(sourceId: Long, state: State, count: Int, updatedAtSeconds: 
       case State.Negative => Negate
     }
 
-    scheduler.put(priority, job(sourceId, tableId, if (tableId > 0) Direction.Forward else Direction.Backward, updatedAt, Priority.Medium, 500, forwardingManager, scheduler))
+    scheduler.put(
+      priority, job(sourceId, tableId, if (tableId > 0) Direction.Forward else Direction.Backward, updatedAt, Priority.Medium, 500, forwardingManager, scheduler, uuidGenerator))
   }
 
   def similar(other: Metadata) = {

--- a/src/main/scala/com/twitter/flockdb/jobs/single/Single.scala
+++ b/src/main/scala/com/twitter/flockdb/jobs/single/Single.scala
@@ -26,7 +26,6 @@ import shards.Shard
 
 case class NodePair(sourceId: Long, destinationId: Long)
 
-
 abstract class SingleJobParser extends JsonJobParser {
   def apply(attributes: Map[String, Any]): JsonJob = {
     val casted = attributes.asInstanceOf[Map[String, AnyVal]]

--- a/src/main/scala/com/twitter/flockdb/queries/ExecuteCompiler.scala
+++ b/src/main/scala/com/twitter/flockdb/queries/ExecuteCompiler.scala
@@ -28,7 +28,7 @@ import jobs.multi
 import operations.{ExecuteOperations, ExecuteOperationType}
 
 
-class ExecuteCompiler(scheduler: PrioritizingJobScheduler, forwardingManager: ForwardingManager, aggregateJobPageSize: Int) {
+class ExecuteCompiler(scheduler: PrioritizingJobScheduler, forwardingManager: ForwardingManager, aggregateJobPageSize: Int, uuidGenerator: UuidGenerator) {
   @throws(classOf[ShardException])
   def apply(program: ExecuteOperations) {
     val now = Time.now
@@ -49,25 +49,25 @@ class ExecuteCompiler(scheduler: PrioritizingJobScheduler, forwardingManager: Fo
           processDestinations(term) { (sourceId, destinationId) =>
             single.Add(sourceId, term.graphId, destinationId, position, time, null, null)
           } {
-            multi.Unarchive(term.sourceId, term.graphId, Direction(term.isForward), time, program.priority, aggregateJobPageSize, null, null)
+            multi.Unarchive(term.sourceId, term.graphId, Direction(term.isForward), time, program.priority, aggregateJobPageSize, null, null, uuidGenerator)
           }
         case ExecuteOperationType.Remove =>
           processDestinations(term) { (sourceId, destinationId) =>
             single.Remove(sourceId, term.graphId, destinationId, position, time, null, null)
           } {
-            multi.RemoveAll(term.sourceId, term.graphId, Direction(term.isForward), time, program.priority, aggregateJobPageSize, null, null)
+            multi.RemoveAll(term.sourceId, term.graphId, Direction(term.isForward), time, program.priority, aggregateJobPageSize, null, null, uuidGenerator)
           }
         case ExecuteOperationType.Archive =>
           processDestinations(term) { (sourceId, destinationId) =>
             single.Archive(sourceId, term.graphId, destinationId, position, time, null, null)
           } {
-            multi.Archive(term.sourceId, term.graphId, Direction(term.isForward), time, program.priority, aggregateJobPageSize, null, null)
+            multi.Archive(term.sourceId, term.graphId, Direction(term.isForward), time, program.priority, aggregateJobPageSize, null, null, uuidGenerator)
           }
         case ExecuteOperationType.Negate =>
           processDestinations(term) { (sourceId, destinationId) =>
             single.Negate(sourceId, term.graphId, destinationId, position, time, null, null)
           } {
-            multi.Negate(term.sourceId, term.graphId, Direction(term.isForward), time, program.priority, aggregateJobPageSize, null, null)
+            multi.Negate(term.sourceId, term.graphId, Direction(term.isForward), time, program.priority, aggregateJobPageSize, null, null, uuidGenerator)
           }
         case n =>
           throw new InvalidQueryException("Unknown operation " + n)

--- a/src/main/scala/com/twitter/flockdb/shards/ReadWriteShardAdapter.scala
+++ b/src/main/scala/com/twitter/flockdb/shards/ReadWriteShardAdapter.scala
@@ -24,7 +24,6 @@ import com.twitter.util.TimeConversions._
 
 class ReadWriteShardAdapter(shard: shards.ReadWriteShard[Shard])
       extends shards.ReadWriteShardAdapter(shard) with Shard with Optimism {
-  def selectIncludingArchived(sourceId: Long, count: Int, cursor: Cursor)                            = shard.readOperation(_.selectIncludingArchived(sourceId, count, cursor))
   def intersect(sourceId: Long, states: Seq[State], destinationIds: Seq[Long])                       = shard.readOperation(_.intersect(sourceId, states, destinationIds))
   def intersectEdges(sourceId: Long, states: Seq[State], destinationIds: Seq[Long])                  = shard.readOperation(_.intersectEdges(sourceId, states, destinationIds))
   def getMetadata(sourceId: Long)                                                                    = shard.readOperation(_.getMetadata(sourceId))

--- a/src/main/scala/com/twitter/flockdb/shards/Shard.scala
+++ b/src/main/scala/com/twitter/flockdb/shards/Shard.scala
@@ -39,7 +39,6 @@ trait Shard extends shards.Shard {
 
   @throws(classOf[shards.ShardException]) def selectAll(cursor: (Cursor, Cursor), count: Int): (Seq[Edge], (Cursor, Cursor))
   @throws(classOf[shards.ShardException]) def selectAllMetadata(cursor: Cursor, count: Int): (Seq[Metadata], Cursor)
-  @throws(classOf[shards.ShardException]) def selectIncludingArchived(sourceId: Long, count: Int, cursor: Cursor): ResultWindow[Long]
   @throws(classOf[shards.ShardException]) def selectByDestinationId(sourceId: Long, states: Seq[State], count: Int, cursor: Cursor): ResultWindow[Long]
   @throws(classOf[shards.ShardException]) def selectByPosition(sourceId: Long, states: Seq[State], count: Int, cursor: Cursor): ResultWindow[Long]
   @throws(classOf[shards.ShardException]) def selectEdges(sourceId: Long, states: Seq[State], count: Int, cursor: Cursor): ResultWindow[Edge]

--- a/src/test/scala/com/twitter/flockdb/integration/FlockFixRegressionSpec.scala
+++ b/src/test/scala/com/twitter/flockdb/integration/FlockFixRegressionSpec.scala
@@ -65,7 +65,7 @@ class FlockFixRegressionSpec extends IntegrationSpecification {
 
       Thread.sleep(1000)
 
-      val job = Unarchive(alice, FOLLOWS, Direction.Forward, Time.now, flockdb.Priority.High, pageSize, flock.edges.forwardingManager, flock.edges.schedule)
+      val job = Unarchive(alice, FOLLOWS, Direction.Forward, Time.now, flockdb.Priority.High, pageSize, flock.edges.forwardingManager, flock.edges.schedule, OrderedUuidGenerator)
       job()
 
       alicesFollowings().size must eventually(be(10))

--- a/src/test/scala/com/twitter/flockdb/unit/EdgesSpec.scala
+++ b/src/test/scala/com/twitter/flockdb/unit/EdgesSpec.scala
@@ -50,7 +50,7 @@ object EdgesSpec extends ConfiguredSpecification with JMocker with ClassMocker {
     val scheduler = mock[PrioritizingJobScheduler]
     val future = mock[Future]
     val copyFactory = mock[CopyJobFactory[Shard]]
-    val flock = new FlockDBThriftAdapter(new EdgesService(nameServer, forwardingManager, copyFactory, scheduler, future, config.intersectionQuery, config.aggregateJobsPageSize), null)
+    val flock = new FlockDBThriftAdapter(new EdgesService(nameServer, forwardingManager, copyFactory, scheduler, future, config.intersectionQuery, config.aggregateJobsPageSize, IdentityUuidGenerator), null)
 
     "add" in {
       Time.withCurrentTimeFrozen { time =>

--- a/src/test/scala/com/twitter/flockdb/unit/ExecuteCompilerSpec.scala
+++ b/src/test/scala/com/twitter/flockdb/unit/ExecuteCompilerSpec.scala
@@ -57,7 +57,7 @@ object ExecuteCompilerSpec extends ConfiguredSpecification with JMocker with Cla
     doBefore {
       scheduler = mock[PrioritizingJobScheduler]
       forwardingManager = mock[ForwardingManager]
-      executeCompiler = new ExecuteCompiler(scheduler, forwardingManager, config.aggregateJobsPageSize)
+      executeCompiler = new ExecuteCompiler(scheduler, forwardingManager, config.aggregateJobsPageSize, IdentityUuidGenerator)
     }
 
     "without execute_at present" in {
@@ -123,7 +123,7 @@ object ExecuteCompilerSpec extends ConfiguredSpecification with JMocker with Cla
             one(scheduler).put(will(beEqual(Priority.Low.id)), nestedJob.capture)
           }
           executeCompiler(program)
-          jsonMatching(List(multi.Unarchive(alice, FOLLOWS, Direction.Forward, now, Priority.Low, config.aggregateJobsPageSize, null, null)), nestedJob.captured.jobs)
+          jsonMatching(List(multi.Unarchive(alice, FOLLOWS, Direction.Forward, now, Priority.Low, config.aggregateJobsPageSize, null, null, IdentityUuidGenerator)), nestedJob.captured.jobs)
         }
 
         "backward" >> {
@@ -133,7 +133,7 @@ object ExecuteCompilerSpec extends ConfiguredSpecification with JMocker with Cla
             one(scheduler).put(will(beEqual(Priority.Low.id)), nestedJob.capture)
           }
           executeCompiler(program)
-          jsonMatching(List(multi.Unarchive(alice, FOLLOWS, Direction.Backward, now, Priority.Low, config.aggregateJobsPageSize, null, null)), nestedJob.captured.jobs)
+          jsonMatching(List(multi.Unarchive(alice, FOLLOWS, Direction.Backward, now, Priority.Low, config.aggregateJobsPageSize, null, null, IdentityUuidGenerator)), nestedJob.captured.jobs)
         }
       }
 
@@ -195,7 +195,7 @@ object ExecuteCompilerSpec extends ConfiguredSpecification with JMocker with Cla
             one(scheduler).put(will(beEqual(Priority.Low.id)), nestedJob.capture)
           }
           executeCompiler(program)
-          jsonMatching(List(multi.RemoveAll(alice, FOLLOWS, Direction.Forward, now, Priority.Low, config.aggregateJobsPageSize, null, null)), nestedJob.captured.jobs)
+          jsonMatching(List(multi.RemoveAll(alice, FOLLOWS, Direction.Forward, now, Priority.Low, config.aggregateJobsPageSize, null, null, IdentityUuidGenerator)), nestedJob.captured.jobs)
         }
 
         "backward" >> {
@@ -205,7 +205,7 @@ object ExecuteCompilerSpec extends ConfiguredSpecification with JMocker with Cla
             one(scheduler).put(will(beEqual(Priority.Low.id)), nestedJob.capture)
           }
           executeCompiler(program)
-          jsonMatching(List(multi.RemoveAll(alice, FOLLOWS, Direction.Backward, now, Priority.Low, config.aggregateJobsPageSize, null, null)), nestedJob.captured.jobs)
+          jsonMatching(List(multi.RemoveAll(alice, FOLLOWS, Direction.Backward, now, Priority.Low, config.aggregateJobsPageSize, null, null, IdentityUuidGenerator)), nestedJob.captured.jobs)
         }
       }
 
@@ -267,7 +267,7 @@ object ExecuteCompilerSpec extends ConfiguredSpecification with JMocker with Cla
             one(scheduler).put(will(beEqual(Priority.Low.id)), nestedJob.capture)
           }
           executeCompiler(program)
-          jsonMatching(List(multi.Archive(alice, FOLLOWS, Direction.Forward, now, Priority.Low, config.aggregateJobsPageSize, null, null)), nestedJob.captured.jobs)
+          jsonMatching(List(multi.Archive(alice, FOLLOWS, Direction.Forward, now, Priority.Low, config.aggregateJobsPageSize, null, null, IdentityUuidGenerator)), nestedJob.captured.jobs)
         }
 
         "backward" >> {
@@ -277,7 +277,7 @@ object ExecuteCompilerSpec extends ConfiguredSpecification with JMocker with Cla
             one(scheduler).put(will(beEqual(Priority.Low.id)), nestedJob.capture)
           }
           executeCompiler(program)
-          jsonMatching(List(multi.Archive(alice, FOLLOWS, Direction.Backward, now, Priority.Low, config.aggregateJobsPageSize, null, null)), nestedJob.captured.jobs)
+          jsonMatching(List(multi.Archive(alice, FOLLOWS, Direction.Backward, now, Priority.Low, config.aggregateJobsPageSize, null, null, IdentityUuidGenerator)), nestedJob.captured.jobs)
         }
       }
 
@@ -339,7 +339,7 @@ object ExecuteCompilerSpec extends ConfiguredSpecification with JMocker with Cla
             one(scheduler).put(will(beEqual(Priority.Low.id)), nestedJob.capture)
           }
           executeCompiler(program)
-          jsonMatching(List(multi.Negate(alice, FOLLOWS, Direction.Forward, now, Priority.Low, config.aggregateJobsPageSize, null, null)), nestedJob.captured.jobs)
+          jsonMatching(List(multi.Negate(alice, FOLLOWS, Direction.Forward, now, Priority.Low, config.aggregateJobsPageSize, null, null, IdentityUuidGenerator)), nestedJob.captured.jobs)
         }
 
         "backward" >> {
@@ -349,7 +349,7 @@ object ExecuteCompilerSpec extends ConfiguredSpecification with JMocker with Cla
             one(scheduler).put(will(beEqual(Priority.Low.id)), nestedJob.capture)
           }
           executeCompiler(program)
-          jsonMatching(List(multi.Negate(alice, FOLLOWS, Direction.Backward, now, Priority.Low, config.aggregateJobsPageSize, null, null)), nestedJob.captured.jobs)
+          jsonMatching(List(multi.Negate(alice, FOLLOWS, Direction.Backward, now, Priority.Low, config.aggregateJobsPageSize, null, null, IdentityUuidGenerator)), nestedJob.captured.jobs)
         }
       }
 

--- a/src/test/scala/com/twitter/flockdb/unit/JobSpec.scala
+++ b/src/test/scala/com/twitter/flockdb/unit/JobSpec.scala
@@ -170,8 +170,8 @@ class JobSpec extends ConfiguredSpecification with JMocker with ClassMocker {
     //                          Input     Before             After             Resulting
     //                          Job       Bob     Mary       Bob     Mary      Job
     test("normal archive",      Archived, Normal, Normal,    Normal, Normal,   Archived, _.apply)
-    test("archive removed",     Archived, Normal, Removed,   Normal, Removed,  Removed, _.apply)
-    test("archive removed",     Archived, Removed, Normal,   Removed, Normal,  Removed, _.apply)
+    test("NOT archive removed", Archived, Normal, Removed,   Normal, Removed,  Removed, _.apply)
+    test("NOT archive removed", Archived, Removed, Normal,   Removed, Normal,  Removed, _.apply)
 
 
     "toJson" in {
@@ -198,7 +198,7 @@ class JobSpec extends ConfiguredSpecification with JMocker with ClassMocker {
 
     "toJson" in {
       Time.withCurrentTimeFrozen { time =>
-        val job = new jobs.multi.Archive(bob, FOLLOWS, Direction.Forward, Time.now, Priority.Low, config.aggregateJobsPageSize, forwardingManager, scheduler)
+        val job = new jobs.multi.Archive(bob, FOLLOWS, Direction.Forward, Time.now, Priority.Low, config.aggregateJobsPageSize, forwardingManager, scheduler, IdentityUuidGenerator)
         val json = job.toJson
         json mustMatch "Archive"
         json mustMatch "\"source_id\":" + bob
@@ -220,7 +220,7 @@ class JobSpec extends ConfiguredSpecification with JMocker with ClassMocker {
 
     "toJson" in {
       Time.withCurrentTimeFrozen { time =>
-        val job = new Unarchive(bob, FOLLOWS, Direction.Forward, Time.now, Priority.Low, config.aggregateJobsPageSize, forwardingManager, scheduler)
+        val job = new Unarchive(bob, FOLLOWS, Direction.Forward, Time.now, Priority.Low, config.aggregateJobsPageSize, forwardingManager, scheduler, IdentityUuidGenerator)
         val json = job.toJson
         json mustMatch "Unarchive"
         json mustMatch "\"source_id\":" + bob
@@ -242,7 +242,7 @@ class JobSpec extends ConfiguredSpecification with JMocker with ClassMocker {
 
     "toJson" in {
       Time.withCurrentTimeFrozen { time =>
-        val job = RemoveAll(bob, FOLLOWS, Direction.Backward, Time.now, Priority.Low, config.aggregateJobsPageSize, forwardingManager, scheduler)
+        val job = RemoveAll(bob, FOLLOWS, Direction.Backward, Time.now, Priority.Low, config.aggregateJobsPageSize, forwardingManager, scheduler, IdentityUuidGenerator)
         val json = job.toJson
         json mustMatch "RemoveAll"
         json mustMatch "\"source_id\":" + bob


### PR DESCRIPTION
allow normal edges to have their position changed;
this requires Multi operations to select full edges and propagate positions so that we don't reorder when we archive/unarchive;
furthermore, this requires position-decoding (uuid unapply) to be available in all bulk jobs so this was a hellish DI propagation;
a longer-term refactoring is to have a true uuid generator that doesn't require retries;
then, the uuid generator would only be needed in the execute compiler
