### PR TITLE
TYPE is no longer a supported modifier on 'CREATE TABLE' as of MySQL 5.1.

### DIFF
--- a/src/main/scala/com/twitter/flockdb/shards/SqlShard.scala
+++ b/src/main/scala/com/twitter/flockdb/shards/SqlShard.scala
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS %s (
   PRIMARY KEY (source_id, state, position),
 
   UNIQUE unique_source_id_destination_id (source_id, destination_id)
-) TYPE=INNODB"""
+) ENGINE=INNODB"""
 
   val METADATA_TABLE_DDL = """
 CREATE TABLE IF NOT EXISTS %s (
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS %s (
   updated_at            INT UNSIGNED             NOT NULL,
 
   PRIMARY KEY (source_id)
-) TYPE=INNODB
+) ENGINE=INNODB
 """
 
   def instantiate(shardInfo: ShardInfo, weight: Int) = {


### PR DESCRIPTION
TYPE is no longer a supported modifier on 'CREATE TABLE' as of MySQL 5.1. ENGINE is a supported modifier as far back as at least 4.0.
