### PR TITLE
Fixed bug in -- operator

### DIFF
--- a/src/main/scala/com/twitter/flockdb/ResultWindow.scala
+++ b/src/main/scala/com/twitter/flockdb/ResultWindow.scala
@@ -76,8 +76,18 @@ class ResultWindow[T](val data: ResultWindowRows[T], val inNextCursor: Cursor, v
   def --(values: Seq[T]) = {
     val rejects = Set(values: _*)
     val newPage = page.filter { row => !rejects.contains(row.id) }
-    val newNextCursor = if (nextCursor == Cursor.End || newPage.size == 0) Cursor.End else newPage(newPage.size - 1).cursor
-    val newPrevCursor = if (prevCursor == Cursor.End || newPage.size == 0) Cursor.End else newPage(0).cursor.reverse
+    val newNextCursor = if (nextCursor == Cursor.End) 
+                          Cursor.End 
+                        else if (newPage.size == 0)
+                          nextCursor
+                        else
+                          newPage(newPage.size - 1).cursor
+    val newPrevCursor = if (prevCursor == Cursor.End) 
+                          Cursor.End 
+                        else if (newPage.size == 0)
+                          prevCursor
+                        else
+                          newPage(0).cursor.reverse
     new ResultWindow(new ResultWindowRows(newPage), newNextCursor, newPrevCursor, count, cursor)
   }
 


### PR DESCRIPTION
consider a case where 1 follows (range 1 10000) and 2 follows (2 9999)
the difference should yield [1, 10000], but in the old code, it would just yield [10000], as the query would end prematurely in the (newPage.size == 0) condition.

In my test config, the max page size was 4000 (which would yield an identical page 2 for both queries, thereby terminating it early with the page.filter eliminating all the values in newPage).
