### PR TITLE
change shard_id to valid format. gizzmo-0.15.1 expanded shard_id validation.

### DIFF
--- a/src/scripts/setup-env.sh
+++ b/src/scripts/setup-env.sh
@@ -60,12 +60,12 @@ echo "Creating shards..."
 i=1
 while [ $i -le 15 ]; do
   /bin/echo -n "$i "
-  exec_sql "DROP TABLE IF EXISTS edges_development.forward_${i}_edges"
-  exec_sql "DROP TABLE IF EXISTS edges_development.forward_${i}_metadata"
-  exec_sql "DROP TABLE IF EXISTS edges_development.backward_${i}_edges"
-  exec_sql "DROP TABLE IF EXISTS edges_development.backward_${i}_metadata"
-  forward_shard=$($gizzmo create -s "INT UNSIGNED" -d "INT UNSIGNED" "com.twitter.flockdb.SqlShard" "localhost/forward_${i}")
-  backward_shard=$($gizzmo create -s "INT UNSIGNED" -d "INT UNSIGNED" "com.twitter.flockdb.SqlShard" "localhost/backward_${i}")
+  exec_sql "DROP TABLE IF EXISTS edges_development.forward_${i}_0000_edges"
+  exec_sql "DROP TABLE IF EXISTS edges_development.forward_${i}_0000_metadata"
+  exec_sql "DROP TABLE IF EXISTS edges_development.backward_${i}_0000_edges"
+  exec_sql "DROP TABLE IF EXISTS edges_development.backward_${i}_0000_metadata"
+  forward_shard=$($gizzmo create -s "INT UNSIGNED" -d "INT UNSIGNED" "com.twitter.flockdb.SqlShard" "localhost/forward_${i}_0000")
+  backward_shard=$($gizzmo create -s "INT UNSIGNED" -d "INT UNSIGNED" "com.twitter.flockdb.SqlShard" "localhost/backward_${i}_0000")
   $gizzmo addforwarding -- $i 0 $forward_shard
   $gizzmo addforwarding -- -$i 0 $backward_shard
   i=$((i + 1))


### PR DESCRIPTION
gizzmo-0.15.1 expanded shard_id validation, so setup-env.sh doesn't work because of shard_id validation error... :(
By this change, it works. 

related issue: 
https://github.com/twitter/flockdb/pull/90#issuecomment-5384146
